### PR TITLE
client: undo set read-timeout for failed GetNameVersion

### DIFF
--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -150,7 +150,8 @@ func (tk TillitisKey) GetNameVersion() (*NameVersion, error) {
 
 	rx, _, err := tk.ReadFrame(rspGetNameVersion, id)
 	if err != nil {
-		return nil, fmt.Errorf("ReadFrame: %w", err)
+		readTimeoutErr := tk.SetReadTimeout(0)
+		return nil, fmt.Errorf("ReadFrame: %w (undoing read-timeout: %w)", err, readTimeoutErr)
 	}
 
 	if err = tk.SetReadTimeout(0); err != nil {


### PR DESCRIPTION
Undo temporary read-timeout in `GetNameVersion()`. (Note that code in this function does not take into account the possibility for another read-timeout already set. This fix only makes `GetNameVersion()` behave as expected under the same assumptions already present.)