### PR TITLE
Introduce safecast, update golangci-lint, fix bug in max app size

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.55.2
+          version: v1.61.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,14 @@ linters:
     - unused
   disable:
     - cyclop
+    - depguard
     - funlen
     - gocognit
     - nestif
     - exhaustruct  # TODO? annoying for now
-    - goerr113  # TODO enable later
+    - err113  # TODO enable later
     - godot
+    - perfsprint
 
 issues:
   max-issues-per-linter: 0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/tillitis/tkeyclient
 
-go 1.19
+go 1.21
+
+toolchain go1.21.1
 
 require (
+	github.com/ccoveille/go-safecast v1.1.0
 	go.bug.st/serial v1.6.2
 	golang.org/x/crypto v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ccoveille/go-safecast v1.1.0 h1:iHKNWaZm+OznO7Eh6EljXPjGfGQsSfa6/sxPlIEKO+g=
+github.com/ccoveille/go-safecast v1.1.0/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,16 +12,10 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-go.bug.st/serial v1.6.1 h1:VSSWmUxlj1T/YlRo2J104Zv3wJFrjHIl/T3NeruWAHY=
-go.bug.st/serial v1.6.1/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=
 go.bug.st/serial v1.6.2/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
-golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -52,6 +52,9 @@ const (
 	// Codes used in app proto responses
 	StatusOK  = 0x00
 	StatusBad = 0x01
+
+	// Size of RAM in the TKey. See TK1_APP_MAX_SIZE in tk1_mem.h
+	AppMaxSize = 0x20000
 )
 
 // TillitisKey is a serial connection to a TKey and the commands that
@@ -273,7 +276,7 @@ func (tk TillitisKey) LoadAppFromFile(fileName string, secretPhrase []byte) erro
 // expected USS is used.
 func (tk TillitisKey) LoadApp(bin []byte, secretPhrase []byte) error {
 	binLen := len(bin)
-	if binLen > 100*1024 { // TK1_APP_MAX_SIZE
+	if binLen > AppMaxSize {
 		return fmt.Errorf("File too big")
 	}
 

--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -419,5 +419,5 @@ func printDigest(md [32]byte) {
 		}
 		digest += " "
 	}
-	le.Printf(digest + "\n")
+	le.Print(digest + "\n")
 }


### PR DESCRIPTION
## Description

When running a more modern version of golangci-lint the gosec linter complains about possible integer overflows (G115) even for unlikely cases. Instead of turning off the warning I experimented with the safecast package and used that to cast the types.

This changes the type signature of UDI's Unpack() to now return an error.
## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
