### PR TITLE
Undo read timeout in GetNameVersion

### DIFF
--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -171,17 +171,12 @@ func (tk TillitisKey) GetNameVersion() (*NameVersion, error) {
 		return nil, err
 	}
 
-	if err = tk.SetReadTimeout(2); err != nil {
-		return nil, err
-	}
+	tk.SetReadTimeoutNoErr(2)
+	defer tk.SetReadTimeoutNoErr(0)
 
 	rx, _, err := tk.ReadFrame(rspGetNameVersion, id)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFrame: %w", err)
-	}
-
-	if err = tk.SetReadTimeout(0); err != nil {
-		return nil, fmt.Errorf("SetReadTimeout: %w", err)
 	}
 
 	nameVer := &NameVersion{}


### PR DESCRIPTION
## Description

- Add a new function that simplifies the usage of defer for setReadTimeout
- Fix the issue of a GateNameVersion not disabling timeout in case of an error.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
