### PR TITLE
Auto detect TKey Castor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/tillitis/tkey-builder:4
+      image: ghcr.io/tillitis/tkey-builder:5rc2
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,13 @@
 # Release notes
 
+## Upcoming
+
+- Detect new Castor USB VID/PID and older TKey models.
+- Include helpful list of UDI Product ID.
+- Update x/crypto to v0.40.0.
+
 ## v1.1.0
+
 - Change license to BSD-2-Clause
 - Follow REUSE specification, see https://reuse.software/
 - Return payload even if NOK is set in header

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/tillitis/tkeyclient
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0
 	go.bug.st/serial v1.6.2
-	golang.org/x/crypto v0.22.0
+	golang.org/x/crypto v0.40.0
 )
 
 require (
 	github.com/creack/goselect v0.1.2 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/sys v0.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,10 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=
 go.bug.st/serial v1.6.2/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
-golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
-golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
-golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
+golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/ports.go
+++ b/ports.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	tillitisUSBVID = "1207"
-	tillitisUSBPID = "8887"
+	tillitisMTAUSBV1VID  = "1207"
+	tillitisMTAUSBV1PID  = "8887"
+	tillitisTKEYUSBV2VID = "1209"
+	tillitisTKEYUSBV2PID = "8885"
 	// Custom errors
 	ErrNoDevice    = constError("no TKey connected")
 	ErrManyDevices = constError("more than one TKey connected")
@@ -21,6 +23,11 @@ const (
 type SerialPort struct {
 	DevPath      string
 	SerialNumber string
+}
+
+func isTKey(vid string, pid string) bool {
+	return (vid == tillitisMTAUSBV1VID && pid == tillitisMTAUSBV1PID) ||
+		(vid == tillitisTKEYUSBV2VID && pid == tillitisTKEYUSBV2PID)
 }
 
 // DetectSerialPort tries to detect an inserted TKey and returns the
@@ -65,7 +72,7 @@ func GetSerialPorts() ([]SerialPort, error) {
 		return ports, nil
 	}
 	for _, port := range portDetails {
-		if port.IsUSB && port.VID == tillitisUSBVID && port.PID == tillitisUSBPID {
+		if port.IsUSB && isTKey(port.VID, port.PID) {
 			ports = append(ports, SerialPort{port.Name, port.SerialNumber})
 		}
 	}

--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -55,6 +55,12 @@ const (
 
 	// Size of RAM in the TKey. See TK1_APP_MAX_SIZE in tk1_mem.h
 	AppMaxSize = 0x20000
+
+	// UDI Product IDs
+	UDIPIDEngSample = 0 // XXX Also used for development purposes
+	UDIPIDAcrab     = 1
+	UDIPIDBellatrix = 2
+	UDIPIDCastor    = 3
 )
 
 // TillitisKey is a serial connection to a TKey and the commands that


### PR DESCRIPTION
## Description

As part of #19 this PR make `DetectSerialPort()` and `GetSerialPorts()` return USB devices that match the TKEY-USB-V2 VID/PID used in TKey Castor as well as the MTA-USB-V1 used in Bellatrix and earlier.

A list of UDI PIDs is added for client apps to use together with the output of `GetUDI()` to detect which TKey variant it is talking to.

## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
