### PR TITLE
Make it default to skip first byte in USS digest unless Castor detected

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## v1.3.1
+
+- Treat USS digest for product ID 8 (TKey Unlocked) like Bellatrix to
+  be backwards compatible with everyone who has an Unlocked who use it
+  as Bellatrix.
+
+Complete
+[changelog](https://github.com/tillitis/tkeyclient/compare/v1.3.0...v1.3.1).
+
 ## v1.3.0
 
 - Version v1.2.0 and earlier had a protocol vulnerability leaving some
@@ -8,10 +17,10 @@
 
   https://github.com/tillitis/tkeyclient/security/advisories/GHSA-4w7r-3222-8h6v
 
+- Adds new option function WithFullUss() for use with Connect().
+
 Complete
 [changelog](https://github.com/tillitis/tkeyclient/compare/v1.2.0...v1.3.0).
-
-- Adds new option function WithFullUss() for use with Connect().
 
 ## v1.2.0
 

--- a/tkeyclient.go
+++ b/tkeyclient.go
@@ -57,10 +57,11 @@ const (
 	AppMaxSize = 0x20000
 
 	// UDI Product IDs
-	UDIPIDEngSample = 0 // XXX Also used for development purposes
-	UDIPIDAcrab     = 1
-	UDIPIDBellatrix = 2
-	UDIPIDCastor    = 3
+	UDIPIDEngSample         = 0 // XXX Also used for development purposes
+	UDIPIDAcrab             = 1
+	UDIPIDBellatrix         = 2
+	UDIPIDCastor            = 3
+	UDIPIDBellatrixUnlocked = 8
 )
 
 // TillitisKey is a serial connection to a TKey and the commands that
@@ -386,11 +387,28 @@ func (tk TillitisKey) loadApp(size int, secretPhrase []byte, pid uint8) error {
 		// Hash user's phrase as USS
 		uss := blake2s.Sum256(secretPhrase)
 
-		if pid >= UDIPIDCastor || tk.forceFullUss {
+		// Skip first byte of computed digest for backwards
+		// compatibility unless forced to send 32 bytes with
+		// the WithFullUss() option function or we have
+		// identified a Castor.
+		switch pid {
+		case UDIPIDCastor:
 			copy(tx[7:], uss[:])
-		} else {
-			// skip first byte for backwards compatibility, 31 byte uss
-			copy(tx[7:], uss[1:])
+
+		case UDIPIDEngSample:
+			fallthrough
+		case UDIPIDAcrab:
+			fallthrough
+		case UDIPIDBellatrix:
+			fallthrough
+		case UDIPIDBellatrixUnlocked:
+			fallthrough
+		default:
+			if tk.forceFullUss {
+				copy(tx[7:], uss[:])
+			} else {
+				copy(tx[7:], uss[1:])
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

- Make it default to skip first byte in USS digest unless Castor detected.

- To be backwards compatible with people using Unlocked as Bellatrix, skip first byte of USS digest when Unlocked is detected.

- Update release notes for this bug fix.

- Release note nit: Move Complete changelog item for v1.3.0 to be last in the note.

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
